### PR TITLE
Refactor posts/:id API to return an array of replies only. Fixes #24

### DIFF
--- a/server/db/posts.js
+++ b/server/db/posts.js
@@ -2,34 +2,13 @@ const connection = require('./')
 
 module.exports = {
   getPosts,
-  getPostWithReplies
+  getReplies
 }
 
 // Sample only: think about what you want this function to actually do...
 function getPosts (db = connection) {
-  return db('posts').select()
-}
-
-function getPostWithReplies (postId, db = connection) {
-  const postData = {
-    post: {},
-    replies: []
-  }
-  return getPost(postId)
-    .then(post => {
-      postData.post = post
-      return getReplies(postId)
-        .then(replies => {
-          postData.replies = replies
-          return postData
-        })
-    })
-}
-
-function getPost (postId, db = connection) {
   return db('posts')
     .select()
-    .where('id', postId)
 }
 
 function getReplies (postId, db = connection) {

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -16,13 +16,13 @@ function getPosts (req, res) {
     })
 }
 
-router.get('/:id', getPostWithReplies)
+router.get('/:id', getReplies)
 
-function getPostWithReplies (req, res) {
+function getReplies (req, res) {
   const postId = req.params.id
-  db.getPostWithReplies(postId)
-    .then(postData => {
-      res.status(200).json(postData)
+  db.getReplies(postId)
+    .then(replies => {
+      res.status(200).json({replies})
     })
     .catch(err => {
       res.status(500).json(err)


### PR DESCRIPTION
Fixes #24 

Sample output for localhost:3001/api/v1/posts/2002

```
{
    "replies": [
        {
            "id": 2,
            "postId": 2002,
            "userId": 1000,
            "displayName": "CC",
            "text": "CC Reply to WW1 ",
            "upvotes": 0,
            "downvotes": 0,
            "reported": 0,
            "createdAt": 1537414348914,
            "updatedAt": null
        },
        {
            "id": 3,
            "postId": 2002,
            "userId": 1001,
            "displayName": "Wobbly Wombat",
            "text": "WW Own reply to WW1",
            "upvotes": 0,
            "downvotes": 0,
            "reported": 0,
            "createdAt": 1537414348914,
            "updatedAt": null
        }
    ]
}
```