### PR TITLE
Refactor posts API to return object with array of posts. Fixes #28

### DIFF
--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -9,7 +9,7 @@ router.get('/', getPosts)
 function getPosts (req, res) {
   db.getPosts()
     .then(posts => {
-      res.status(200).json(posts)
+      res.status(200).json({posts})
     })
     .catch(err => {
       res.status(500).json(err)


### PR DESCRIPTION
Fixes #28

Sample output for localhost:3001/api/v1/posts

```
{
    "posts": [
        {
            "id": 2000,
            "userId": 1000,
            "displayName": "Curious Capybara",
            "title": "CC Post 1",
            "body": "CC Post 1 Body Content",
            "upvotes": 0,
            "downvotes": 0,
            "reported": 0,
            "createdAt": 1537414348908,
            "updatedAt": null
        },
        {
            "id": 2001,
            "userId": 1001,
            "displayName": "Wobbly Wombat",
            "title": "WW Post 1",
            "body": "WW Post 1 Body Content",
            "upvotes": 0,
            "downvotes": 0,
            "reported": 0,
            "createdAt": 1537414348908,
            "updatedAt": null
        },
        {
            "id": 2002,
            "userId": 1001,
            "displayName": "Wobbly Wombat",
            "title": "WW Post 2",
            "body": "WW Post 2 Body Content",
            "upvotes": 0,
            "downvotes": 0,
            "reported": 0,
            "createdAt": 1537414348908,
            "updatedAt": null
        }
    ]
}
```